### PR TITLE
Don't overwrite gravity _if_ specified in yaml config file

### DIFF
--- a/isaacgymenvs/tasks/base/vec_task.py
+++ b/isaacgymenvs/tasks/base/vec_task.py
@@ -260,9 +260,10 @@ class VecTask(Env):
         """
         if axis == 'z':
             sim_params.up_axis = gymapi.UP_AXIS_Z
-            sim_params.gravity.x = 0
-            sim_params.gravity.y = 0
-            sim_params.gravity.z = -9.81
+            if not hasattr(sim_params, 'gravity'):
+                sim_params.gravity.x = 0
+                sim_params.gravity.y = 0
+                sim_params.gravity.z = -9.81
             return 2
         return 1
 


### PR DESCRIPTION
Currently, whatever the user writes into the config file for gravity is overwritten in `vec_task.py`, which is both confusing and not useful. Now checks if the cfg specifies gravity, and only writes default values if it doesn't.