### PR TITLE
isaacgym_task_map is now only used in train.py, which makes it possib…

### DIFF
--- a/isaacgymenvs/tasks/__init__.py
+++ b/isaacgymenvs/tasks/__init__.py
@@ -25,35 +25,3 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-
-from tasks.allegro_hand import AllegroHand
-from tasks.ant import Ant
-from tasks.anymal import Anymal
-from tasks.anymal_terrain import AnymalTerrain
-from tasks.ball_balance import BallBalance
-from tasks.cartpole import Cartpole 
-from tasks.franka_cabinet import FrankaCabinet
-from tasks.humanoid import Humanoid
-from tasks.humanoid_amp import HumanoidAMP
-from tasks.ingenuity import Ingenuity
-from tasks.quadcopter import Quadcopter
-from tasks.shadow_hand import ShadowHand
-from tasks.trifinger import Trifinger
-
-# Mappings from strings to environments
-isaacgym_task_map = {
-    "AllegroHand": AllegroHand,
-    "Ant": Ant,
-    "Anymal": Anymal,
-    "AnymalTerrain": AnymalTerrain,
-    "BallBalance": BallBalance,
-    "Cartpole": Cartpole,
-    "FrankaCabinet": FrankaCabinet,
-    "Humanoid": Humanoid,
-    "HumanoidAMP": HumanoidAMP,
-    "Ingenuity": Ingenuity,
-    "Quadcopter": Quadcopter,
-    "ShadowHand": ShadowHand,
-    "Trifinger": Trifinger,
-}

--- a/isaacgymenvs/train.py
+++ b/isaacgymenvs/train.py
@@ -51,6 +51,19 @@ from isaacgymenvs.learning import amp_players
 from isaacgymenvs.learning import amp_models
 from isaacgymenvs.learning import amp_network_builder
 
+from tasks.allegro_hand import AllegroHand
+from tasks.ant import Ant
+from tasks.anymal import Anymal
+from tasks.anymal_terrain import AnymalTerrain
+from tasks.ball_balance import BallBalance
+from tasks.cartpole import Cartpole 
+from tasks.franka_cabinet import FrankaCabinet
+from tasks.humanoid import Humanoid
+from tasks.humanoid_amp import HumanoidAMP
+from tasks.ingenuity import Ingenuity
+from tasks.quadcopter import Quadcopter
+from tasks.shadow_hand import ShadowHand
+from tasks.trifinger import Trifinger
 
 ## OmegaConf & Hydra Config
 
@@ -78,11 +91,28 @@ def launch_rlg_hydra(cfg: DictConfig):
     # sets seed. if seed is -1 will pick a random one
     cfg.seed = set_seed(cfg.seed, torch_deterministic=cfg.torch_deterministic)
 
+    # Mappings from strings to environments
+    isaacgym_task_map = {
+        "AllegroHand": AllegroHand,
+        "Ant": Ant,
+        "Anymal": Anymal,
+        "AnymalTerrain": AnymalTerrain,
+        "BallBalance": BallBalance,
+        "Cartpole": Cartpole,
+        "FrankaCabinet": FrankaCabinet,
+        "Humanoid": Humanoid,
+        "HumanoidAMP": HumanoidAMP,
+        "Ingenuity": Ingenuity,
+        "Quadcopter": Quadcopter,
+        "ShadowHand": ShadowHand,
+        "Trifinger": Trifinger,
+    }
+
     # `create_rlgpu_env` is environment construction function which is passed to RL Games and called internally.
     # We use the helper function here to specify the environment config.
     create_rlgpu_env = get_rlgames_env_creator(
         omegaconf_to_dict(cfg.task),
-        cfg.task_name,
+        isaacgym_task_map[cfg.task_name],
         cfg.sim_device,
         cfg.rl_device,
         cfg.graphics_device_id,

--- a/isaacgymenvs/utils/rlgames_utils.py
+++ b/isaacgymenvs/utils/rlgames_utils.py
@@ -31,15 +31,15 @@ from rl_games.common.algo_observer import AlgoObserver
 from rl_games.algos_torch import torch_ext
 import torch
 import numpy as np
-from typing import Callable
+from typing import Callable, Type
 
-from tasks import isaacgym_task_map
+from isaacgymenvs.tasks.base.vec_task import VecTask
 
 
 def get_rlgames_env_creator(
         # used to create the vec task
         task_config: dict,
-        task_name: str,
+        task_class: Type[VecTask],
         sim_device: str,
         rl_device: str,
         graphics_device_id: int,
@@ -84,7 +84,7 @@ def get_rlgames_env_creator(
             _rl_device = rl_device
 
         # create native task and pass custom config
-        env = isaacgym_task_map[task_name](
+        env = task_class(
             cfg=task_config,
             sim_device=_sim_device,
             graphics_device_id=graphics_device_id,


### PR DESCRIPTION
…le to use IsaacGymEnvs as a Python library instead of requiring a fork

For my project I have a custom robot/task that inherits from VecTask, but there are a few issues with the way the task map is set up that prevent using IsaacGymEnvs as a library:
- Can't create a custom task with `get_rlgames_env_creator()` since it relies on the task map
- Can't import from `rlgame_utils` or `vec_task` since they import from `tasks` which is not installed

These minor changes make it possible to use IsaacGymEnvs as a standalone library. Custom tasks can then be redistributed without including code from IsaacGymEnvs other than a modified `train.py`.