### PR TITLE
Allow usage of isaacgymenvs code as package outside of repo

### DIFF
--- a/docs/framework.md
+++ b/docs/framework.md
@@ -106,7 +106,7 @@ To use Isaac Gym's APIs, we need the following imports
 from isaacgym import gymtorch
 from isaacgym import gymapi
 
-from tasks.base.vec_task import VecTask
+from isaacgymenvs.tasks.base.vec_task import VecTask
 ```
 
 Then, we need to create a Task class that extends from VecTask
@@ -162,7 +162,7 @@ task to the imports and `isaacgym_task_map` dict in the `tasks` [\_\_init\_\_.py
 
 
 ```python
-from tasks.my_new_task import MyNewTask
+from isaacgymenvs.tasks.my_new_task import MyNewTask
 ...
 isaac_gym_task_map = {
     'Anymal': Anymal,
@@ -189,7 +189,7 @@ If you have existing environments set up with Isaac Gym Preview 2 release or ear
 
 ### Imports ###
 * The `torch_jit_utils` script has been moved to IsaacGymEnvs. Tasks that are importing from `rlgpu.utils.torch_jit_utils` should now import from `utils.torch_jit_utils`.
-* The original `BaseTask` class has been converted to `VecTask` in IsaacGymEnvs. All tasks inheriting from the previous `BaseTask` should modify `from rlgpu.tasks.base.base_task import BaseTask` to `from tasks.base.vec_task import VecTask`.
+* The original `BaseTask` class has been converted to `VecTask` in IsaacGymEnvs. All tasks inheriting from the previous `BaseTask` should modify `from rlgpu.tasks.base.base_task import BaseTask` to `from isaacgymenvs.tasks.base.vec_task import VecTask`.
 
 ### Class Definition ###
 * Your task class should now inherit from `VecTask` instead of the previous `BaseTask`.

--- a/isaacgymenvs/learning/amp_continuous.py
+++ b/isaacgymenvs/learning/amp_continuous.py
@@ -41,8 +41,8 @@ from torch import optim
 import torch 
 from torch import nn
 
-import learning.replay_buffer as replay_buffer
-import learning.common_agent as common_agent 
+import isaacgymenvs.learning.replay_buffer as replay_buffer
+import isaacgymenvs.learning.common_agent as common_agent 
 
 from tensorboardX import SummaryWriter
 

--- a/isaacgymenvs/learning/amp_players.py
+++ b/isaacgymenvs/learning/amp_players.py
@@ -32,7 +32,7 @@ from rl_games.algos_torch import torch_ext
 from rl_games.algos_torch.running_mean_std import RunningMeanStd
 from rl_games.common.player import BasePlayer
 
-import learning.common_player as common_player
+import isaacgymenvs.learning.common_player as common_player
 
 
 class AMPPlayerContinuous(common_player.CommonPlayer):

--- a/isaacgymenvs/learning/common_agent.py
+++ b/isaacgymenvs/learning/common_agent.py
@@ -46,7 +46,7 @@ from rl_games.common import vecenv
 import torch
 from torch import optim
 
-import learning.amp_datasets as amp_datasets
+import isaacgymenvs.learning.amp_datasets as amp_datasets
 
 from tensorboardX import SummaryWriter
 

--- a/isaacgymenvs/learning/hrl_continuous.py
+++ b/isaacgymenvs/learning/hrl_continuous.py
@@ -45,10 +45,10 @@ from rl_games.common import vecenv
 import torch
 from torch import optim
 
-import learning.common_agent as common_agent 
-import learning.gen_amp as gen_amp
-import learning.gen_amp_models as gen_amp_models
-import learning.gen_amp_network_builder as gen_amp_network_builder
+import isaacgymenvs.learning.common_agent as common_agent 
+import isaacgymenvs.learning.gen_amp as gen_amp
+import isaacgymenvs.learning.gen_amp_models as gen_amp_models
+import isaacgymenvs.learning.gen_amp_network_builder as gen_amp_network_builder
 
 from tensorboardX import SummaryWriter
 

--- a/isaacgymenvs/tasks/__init__.py
+++ b/isaacgymenvs/tasks/__init__.py
@@ -27,19 +27,19 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-from tasks.allegro_hand import AllegroHand
-from tasks.ant import Ant
-from tasks.anymal import Anymal
-from tasks.anymal_terrain import AnymalTerrain
-from tasks.ball_balance import BallBalance
-from tasks.cartpole import Cartpole 
-from tasks.franka_cabinet import FrankaCabinet
-from tasks.humanoid import Humanoid
-from tasks.humanoid_amp import HumanoidAMP
-from tasks.ingenuity import Ingenuity
-from tasks.quadcopter import Quadcopter
-from tasks.shadow_hand import ShadowHand
-from tasks.trifinger import Trifinger
+from isaacgymenvs.tasks.allegro_hand import AllegroHand
+from isaacgymenvs.tasks.ant import Ant
+from isaacgymenvs.tasks.anymal import Anymal
+from isaacgymenvs.tasks.anymal_terrain import AnymalTerrain
+from isaacgymenvs.tasks.ball_balance import BallBalance
+from isaacgymenvs.tasks.cartpole import Cartpole
+from isaacgymenvs.tasks.franka_cabinet import FrankaCabinet
+from isaacgymenvs.tasks.humanoid import Humanoid
+from isaacgymenvs.tasks.humanoid_amp import HumanoidAMP
+from isaacgymenvs.tasks.ingenuity import Ingenuity
+from isaacgymenvs.tasks.quadcopter import Quadcopter
+from isaacgymenvs.tasks.shadow_hand import ShadowHand
+from isaacgymenvs.tasks.trifinger import Trifinger
 
 # Mappings from strings to environments
 isaacgym_task_map = {

--- a/isaacgymenvs/tasks/amp/utils_amp/motion_lib.py
+++ b/isaacgymenvs/tasks/amp/utils_amp/motion_lib.py
@@ -35,7 +35,7 @@ from ..poselib.poselib.core.rotation3d import *
 from isaacgym.torch_utils import *
 from isaacgymenvs.utils.torch_jit_utils import *
 
-from tasks.amp.humanoid_amp_base import DOF_BODY_IDS, DOF_OFFSETS
+from isaacgymenvs.tasks.amp.humanoid_amp_base import DOF_BODY_IDS, DOF_OFFSETS
 
 
 class MotionLib():

--- a/isaacgymenvs/tasks/anymal_terrain.py
+++ b/isaacgymenvs/tasks/anymal_terrain.py
@@ -32,7 +32,7 @@ import os, time
 from isaacgym.torch_utils import *
 from isaacgym import gymtorch
 from isaacgym import gymapi
-from tasks.base.vec_task import VecTask
+from isaacgymenvs.tasks.base.vec_task import VecTask
 
 import torch
 from typing import Tuple, Dict

--- a/isaacgymenvs/tasks/ball_balance.py
+++ b/isaacgymenvs/tasks/ball_balance.py
@@ -34,7 +34,7 @@ import xml.etree.ElementTree as ET
 
 from isaacgym import gymutil, gymtorch, gymapi
 from isaacgym.torch_utils import *
-from tasks.base.vec_task import VecTask
+from isaacgymenvs.tasks.base.vec_task import VecTask
 
 
 def _indent_xml(elem, level=0):

--- a/isaacgymenvs/tasks/cartpole.py
+++ b/isaacgymenvs/tasks/cartpole.py
@@ -31,7 +31,7 @@ import os
 import torch
 
 from isaacgym import gymutil, gymtorch, gymapi
-from tasks.base.vec_task import VecTask
+from isaacgymenvs.tasks.base.vec_task import VecTask
 
 class Cartpole(VecTask):
 

--- a/isaacgymenvs/tasks/franka_cabinet.py
+++ b/isaacgymenvs/tasks/franka_cabinet.py
@@ -32,7 +32,7 @@ import torch
 
 from isaacgym import gymutil, gymtorch, gymapi
 from isaacgym.torch_utils import *
-from tasks.base.vec_task import VecTask
+from isaacgymenvs.tasks.base.vec_task import VecTask
 
 
 class FrankaCabinet(VecTask):

--- a/isaacgymenvs/tasks/ingenuity.py
+++ b/isaacgymenvs/tasks/ingenuity.py
@@ -32,8 +32,8 @@ import os
 import torch
 import xml.etree.ElementTree as ET
 
-from utils.torch_jit_utils import *
-from tasks.base.vec_task import VecTask
+from isaacgymenvs.utils.torch_jit_utils import *
+from isaacgymenvs.tasks.base.vec_task import VecTask
 
 from isaacgym import gymutil, gymtorch, gymapi
 

--- a/isaacgymenvs/tasks/quadcopter.py
+++ b/isaacgymenvs/tasks/quadcopter.py
@@ -33,7 +33,7 @@ import torch
 import xml.etree.ElementTree as ET
 
 from isaacgym import gymutil, gymtorch, gymapi
-from utils.torch_jit_utils import *
+from isaacgymenvs.utils.torch_jit_utils import *
 from .base.vec_task import VecTask
 
 

--- a/isaacgymenvs/train.py
+++ b/isaacgymenvs/train.py
@@ -39,7 +39,7 @@ from hydra.utils import to_absolute_path
 from isaacgymenvs.utils.reformat import omegaconf_to_dict, print_dict
 from isaacgymenvs.utils.rlgames_utils import RLGPUEnv, RLGPUAlgoObserver, get_rlgames_env_creator
 
-from utils.utils import set_np_formatting, set_seed
+from isaacgymenvs.utils.utils import set_np_formatting, set_seed
 
 from rl_games.common import env_configurations, vecenv
 from rl_games.torch_runner import Runner

--- a/isaacgymenvs/utils/rlgames_utils.py
+++ b/isaacgymenvs/utils/rlgames_utils.py
@@ -33,7 +33,7 @@ import torch
 import numpy as np
 from typing import Callable
 
-from tasks import isaacgym_task_map
+from isaacgymenvs.tasks import isaacgym_task_map
 
 
 def get_rlgames_env_creator(


### PR DESCRIPTION
The imports have been adjusted so that the user no longer has to be working in the ```IsaacGymEnvs/isaacgymenvs```  directory in order to execute this package's code.

I believe that this is a more elegant solution than pull request https://github.com/NVIDIA-Omniverse/IsaacGymEnvs/pull/25 as the user would be able to run all of the envs without having to use this repo's ```train.py```; the user would not have to copy over all of the imports that pull request https://github.com/NVIDIA-Omniverse/IsaacGymEnvs/pull/25 suggests copying over into this repo's ```train.py```.

This is useful if the user would like to use IsaacGymEnvs with their own learning frameworks, outside of the IsaacGymEnvs repo.
