### PR TITLE
Update train.py

### DIFF
--- a/isaacgymenvs/train.py
+++ b/isaacgymenvs/train.py
@@ -140,6 +140,7 @@ def launch_rlg_hydra(cfg: DictConfig):
         return runner
 
     rlg_config_dict = omegaconf_to_dict(cfg.train)
+    rlg_config_dict['params']['config']['device']=cfg.rl_device
 
     # convert CLI arguments into dictionory
     # create runner and set the settings


### PR DESCRIPTION
A command like "python train.py task=Ant headless=True sim_device=cpu rl_device=cpu" can not work correctly. The reason is "rlg_config_dict" doesn't include the information of "rl_device".

In the "a2c_common.py" of "rl_games", there is a line of code: "self.ppo_device = config.get('device', 'cuda:0')". So the RL algorithm will always only work on the cuda:0.