### PR TITLE
Refactor train.py and cfg to allow hydra tab completion

### DIFF
--- a/isaacgymenvs/cfg/config.yaml
+++ b/isaacgymenvs/cfg/config.yaml
@@ -61,7 +61,8 @@ headless: False
 defaults:
   - task: Ant
   - train: ${task}PPO
-  - hydra/job_logging: disabled
+  - override hydra/job_logging: disabled
+  - _self_
 
 # set the directory where the output files get saved
 hydra:

--- a/isaacgymenvs/train.py
+++ b/isaacgymenvs/train.py
@@ -28,21 +28,9 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-import logging
-import os
-import datetime
-
-# noinspection PyUnresolvedReferences
-import isaacgym
 
 import hydra
-from hydra.utils import to_absolute_path
-from isaacgymenvs.tasks import isaacgym_task_map
 from omegaconf import DictConfig, OmegaConf
-import gym
-
-from isaacgymenvs.utils.reformat import omegaconf_to_dict, print_dict
-from isaacgymenvs.utils.utils import set_np_formatting, set_seed
 
 def preprocess_train_config(cfg, config_dict):
     """
@@ -67,9 +55,20 @@ def preprocess_train_config(cfg, config_dict):
     return config_dict
 
 
-@hydra.main(config_name="config", config_path="./cfg")
+@hydra.main(version_base="1.1", config_name="config", config_path="./cfg")
 def launch_rlg_hydra(cfg: DictConfig):
-    
+    import logging
+    import os
+    import datetime
+    # noinspection PyUnresolvedReferences
+    import isaacgym
+
+    from hydra.utils import to_absolute_path
+    from isaacgymenvs.tasks import isaacgym_task_map
+    import gym
+
+    from isaacgymenvs.utils.reformat import omegaconf_to_dict, print_dict
+    from isaacgymenvs.utils.utils import set_np_formatting, set_seed
     from isaacgymenvs.utils.rlgames_utils import RLGPUEnv, RLGPUAlgoObserver, MultiObserver, ComplexObsRLGPUEnv
     from isaacgymenvs.utils.wandb_utils import WandbAlgoObserver
     from rl_games.common import env_configurations, vecenv


### PR DESCRIPTION
# Goal 

Add [Hydra tab completion](https://hydra.cc/docs/tutorials/basic/running_your_app/tab_completion/) for `train.py` to help users write commands more quickly, rather than needing to constantly check the config yaml files to remember the parameter names (eg. I kept forgetting if it was `num_envs` or `numEnvs`)

![hydra_tab_completion](https://user-images.githubusercontent.com/26510814/231017711-a5d8c566-d988-4d52-ad0d-6dfa905d34b6.gif)

^ Example gif showing what the tab completion looks like

# How To Use

To set up, run:
```
eval "$(python train.py -sc install=bash)"
```

Then simply type `python train.py` and then the tab completion will work. You can start typing a parameter name (eg. `python train.py num_` and press tab to either autocomplete or show possible completions.

# Low-Level Details About Changes

* Needed to move many `train.py` imports into the function because these imports caused prints to terminal that made the tab completion setup not work correctly
* Needed to explicitly add version_base 1.1 to avoid warning messages that made the tab completion not work as nicely (https://hydra.cc/docs/upgrades/version_base/). This matches the behavior from before (not setting the version base makes it default to 1.1, so this is just more explicit)
* Needed to add the explicit `_self_` at the end of the default list in hydra to avoid warning messages that made the tab completion not work as nicely (https://hydra.cc/docs/upgrades/1.0_to_1.1/default_composition_order/). This matches the behavior from before.
* Needed to add `override` in config file to avoid warning (https://hydra.cc/docs/1.2/upgrades/1.0_to_1.1/defaults_list_override/)

![image](https://user-images.githubusercontent.com/26510814/231018561-62b34c96-ec27-4213-be89-b6ccb8b6fee6.png)
^ currently using version_base 1.1, so set this explicitly

![image](https://user-images.githubusercontent.com/26510814/231018674-616c1309-2338-4bde-8f0a-fe4a13fa32f6.png)
^ using version 1.1, so put `_self_` last

![image](https://user-images.githubusercontent.com/26510814/231018785-93838e4a-07f7-450c-aa4c-e505ce190df1.png)
^ add explicit override term
