### PR TITLE
Fix typo in tasks/franka_cube_stack.py

### DIFF
--- a/isaacgymenvs/tasks/franka_cube_stack.py
+++ b/isaacgymenvs/tasks/franka_cube_stack.py
@@ -543,7 +543,7 @@ class FrankaCubeStack(VecTask):
         elif cube.lower() == 'b':
             this_cube_state_all = self._init_cubeB_state
             other_cube_state = self._init_cubeA_state[env_ids, :]
-            cube_heights = self.states["cubeA_size"]
+            cube_heights = self.states["cubeB_size"]
         else:
             raise ValueError(f"Invalid cube specified, options are 'A' and 'B'; got: {cube}")
 


### PR DESCRIPTION
There's a typo in frank_cube_stack.py, which results in an incorrect block pose.