### PR TITLE
Fix usage of enableCameraSensors

### DIFF
--- a/isaacgymenvs/cfg/task/AllegroHand.yaml
+++ b/isaacgymenvs/cfg/task/AllegroHand.yaml
@@ -61,6 +61,9 @@ env:
     assetFileNameEgg: "mjcf/open_ai_assets/hand/egg.xml"
     assetFileNamePen: "mjcf/open_ai_assets/hand/pen.xml"
 
+  # set to True if you use camera sensors in the environment
+  enableCameraSensors: False
+
 task:
   randomize: False
   randomization_params:
@@ -154,9 +157,6 @@ task:
             distribution: "uniform"
             # schedule: "linear"  # "linear" will scale the current random sample by `min(current num steps, schedule_steps) / schedule_steps`
             # schedule_steps: 30000
-
-  # set to True if you use camera sensors in the environment
-  enableCameraSensors: False
 
 sim:
   dt: 0.01667 # 1/60

--- a/isaacgymenvs/cfg/task/AllegroHandDextremeADR.yaml
+++ b/isaacgymenvs/cfg/task/AllegroHandDextremeADR.yaml
@@ -96,6 +96,9 @@ env:
     assetFileNameEgg: "mjcf/open_ai_assets/hand/egg.xml"
     assetFileNamePen: "mjcf/open_ai_assets/hand/pen.xml"
 
+  # set to True if you use camera sensors in the environment
+  enableCameraSensors: False
+
 task:
   randomize: True
   randomization_params:
@@ -417,9 +420,6 @@ task:
         limits: [0.0, 1.0]
         delta: 0.01
         delta_style: 'additive'
-
-  # set to True if you use camera sensors in the environment
-  enableCameraSensors: False
 
 sim:
   dt: 0.01667 # 1/60

--- a/isaacgymenvs/cfg/task/AllegroHandDextremeManualDR.yaml
+++ b/isaacgymenvs/cfg/task/AllegroHandDextremeManualDR.yaml
@@ -100,6 +100,9 @@ env:
     assetFileNameEgg: "mjcf/open_ai_assets/hand/egg.xml"
     assetFileNamePen: "mjcf/open_ai_assets/hand/pen.xml"
 
+  # set to True if you use camera sensors in the environment
+  enableCameraSensors: False
+
 task:
   randomize: True
   randomization_params:
@@ -238,10 +241,6 @@ task:
             range: [0.0, 0.4]
             operation: "additive"
             distribution: "uniform"
-
-
-  # set to True if you use camera sensors in the environment
-  enableCameraSensors: False
 
 sim:
   dt: 0.01667 # 1/60

--- a/isaacgymenvs/cfg/task/AllegroHandLSTM.yaml
+++ b/isaacgymenvs/cfg/task/AllegroHandLSTM.yaml
@@ -99,6 +99,9 @@ env:
     assetFileNameEgg: "mjcf/open_ai_assets/hand/egg.xml"
     assetFileNamePen: "mjcf/open_ai_assets/hand/pen.xml"
 
+  # set to True if you use camera sensors in the environment
+  enableCameraSensors: False
+
 task:
   randomize: True
   randomization_params:
@@ -246,9 +249,6 @@ task:
             range: [0.0, 0.4]
             operation: "additive"
             distribution: "uniform"
-
-  # set to True if you use camera sensors in the environment
-  enableCameraSensors: False
 
 sim:
   dt: 0.01667 # 1/60

--- a/isaacgymenvs/tasks/base/vec_task.py
+++ b/isaacgymenvs/tasks/base/vec_task.py
@@ -93,7 +93,7 @@ class Env(ABC):
         # if training in a headless mode
         self.headless = headless
 
-        enable_camera_sensors = config.get("enableCameraSensors", False)
+        enable_camera_sensors = config["env"].get("enableCameraSensors", False)
         self.graphics_device_id = graphics_device_id
         if enable_camera_sensors == False and self.headless == True:
             self.graphics_device_id = -1


### PR DESCRIPTION
# Goal

Enable proper use of the `enableCameraSensors` config parameter.

# Problem

The current behavior results in `enableCameraSensors` always being false.

# Reason

`enable_camera_sensors = config.get("enableCameraSensors", False)` always returns False because this is reading from the wrong part of the config. In almost all of the task yaml files, `enableCameraSensors` is defined under `task.env`, but in the code it is looking under `task`. The use of the `get` and default value made this bug pass by silently, but I noticed it when trying to get my camera sensors to work in a headless training environment.

I also fixed the AllegroHands' yaml files to be consistent with the others (before they were under `task.task`).

# How To Check

Can manually check using:
```
git grep -B 200 enableCameraSensors:
```

I also wrote a small python script called `check_for_enableCameraSensors.py` that does a similar check if placed in `IsaacGymEnvs/isaacgymenvs`.

```
cd IsaacGymEnvs/isaacgymenvs
python check_for_enableCameraSensors.py
```

## Before Change
Note the ['task, 'task', 'enableCameraSensors'] in AllegroHand is inconsistent (it was the same in AllegroHandManualDR and AllegroHandADR too, but failed to load for some reason).
```
Path to enableCameraSensors in AllegroHand: ['task', 'task', 'enableCameraSensors']
enableCameraSensors not in AllegroKuka
Failed to load AllegroKukaTwoArms
Failed to load AllegroHandManualDR
Failed to load AllegroHandADR
Path to enableCameraSensors in Ant: ['task', 'env', 'enableCameraSensors']
Path to enableCameraSensors in Anymal: ['task', 'env', 'enableCameraSensors']
Path to enableCameraSensors in AnymalTerrain: ['task', 'env', 'enableCameraSensors']
Path to enableCameraSensors in BallBalance: ['task', 'env', 'enableCameraSensors']
Path to enableCameraSensors in Cartpole: ['task', 'env', 'enableCameraSensors']
enableCameraSensors not in FactoryTaskGears
enableCameraSensors not in FactoryTaskInsertion
enableCameraSensors not in FactoryTaskNutBoltPick
enableCameraSensors not in FactoryTaskNutBoltPlace
enableCameraSensors not in FactoryTaskNutBoltScrew
Path to enableCameraSensors in FrankaCabinet: ['task', 'env', 'enableCameraSensors']
Path to enableCameraSensors in FrankaCubeStack: ['task', 'env', 'enableCameraSensors']
Path to enableCameraSensors in Humanoid: ['task', 'env', 'enableCameraSensors']
enableCameraSensors not in HumanoidAMP
Path to enableCameraSensors in Ingenuity: ['task', 'env', 'enableCameraSensors']
Path to enableCameraSensors in Quadcopter: ['task', 'env', 'enableCameraSensors']
Path to enableCameraSensors in ShadowHand: ['task', 'env', 'enableCameraSensors']
Path to enableCameraSensors in Trifinger: ['task', 'env', 'enableCameraSensors']
```

## After
Note the consistent ['task, 'env', 'enableCameraSensors'] now.
```
Path to enableCameraSensors in AllegroHand: ['task', 'env', 'enableCameraSensors']
enableCameraSensors not in AllegroKuka
Failed to load AllegroKukaTwoArms
Failed to load AllegroHandManualDR
Failed to load AllegroHandADR
Path to enableCameraSensors in Ant: ['task', 'env', 'enableCameraSensors']
Path to enableCameraSensors in Anymal: ['task', 'env', 'enableCameraSensors']
Path to enableCameraSensors in AnymalTerrain: ['task', 'env', 'enableCameraSensors']
Path to enableCameraSensors in BallBalance: ['task', 'env', 'enableCameraSensors']
Path to enableCameraSensors in Cartpole: ['task', 'env', 'enableCameraSensors']
enableCameraSensors not in FactoryTaskGears
enableCameraSensors not in FactoryTaskInsertion
enableCameraSensors not in FactoryTaskNutBoltPick
enableCameraSensors not in FactoryTaskNutBoltPlace
enableCameraSensors not in FactoryTaskNutBoltScrew
Path to enableCameraSensors in FrankaCabinet: ['task', 'env', 'enableCameraSensors']
Path to enableCameraSensors in FrankaCubeStack: ['task', 'env', 'enableCameraSensors']
Path to enableCameraSensors in Humanoid: ['task', 'env', 'enableCameraSensors']
enableCameraSensors not in HumanoidAMP
Path to enableCameraSensors in Ingenuity: ['task', 'env', 'enableCameraSensors']
Path to enableCameraSensors in Quadcopter: ['task', 'env', 'enableCameraSensors']
Path to enableCameraSensors in ShadowHand: ['task', 'env', 'enableCameraSensors']
Path to enableCameraSensors in Trifinger: ['task', 'env', 'enableCameraSensors']
```