### PR TITLE
fix poselib visualization showing blank figure

### DIFF
--- a/isaacgymenvs/tasks/amp/poselib/poselib/visualization/plt_plotter.py
+++ b/isaacgymenvs/tasks/amp/poselib/poselib/visualization/plt_plotter.py
@@ -237,7 +237,7 @@ class Matplotlib3DPlotter(BasePlotter):
 
     def __init__(self, task: "BasePlotterTask") -> None:
         self._fig = plt.figure()
-        self._ax = p3.Axes3D(self._fig)
+        self._ax = self._fig.add_axes(p3.Axes3D(self._fig))
         self._artist_cache = {}
 
         self._create_impl_callables = {


### PR DESCRIPTION
### Bug Fix
#160:  plot_skeleton_state with Nothing
### Previous outcome
The outcome figure is blank.
![image](https://github.com/NVIDIA-Omniverse/IsaacGymEnvs/assets/29546841/7aa9fbb7-f3de-4a7a-ae48-3288155c9938)
### Corrected outcome
The figure shows correctly the visualization plots
![image](https://github.com/NVIDIA-Omniverse/IsaacGymEnvs/assets/29546841/28b8179b-ce18-4f11-ad33-b114b9b89691)

### Details
[Issue #24639 Matplotlib](https://github.com/matplotlib/matplotlib/issues/24639#issuecomment-1338928343)
