### PR TITLE
Bug Fix in AMP Hybrid Init

### DIFF
--- a/isaacgymenvs/tasks/amp/humanoid_amp_base.py
+++ b/isaacgymenvs/tasks/amp/humanoid_amp_base.py
@@ -145,6 +145,7 @@ class HumanoidAMPBase(VecTask):
 
     def reset_idx(self, env_ids):
         self._reset_actors(env_ids)
+        self._reset_env_tensors(env_ids)
         self._refresh_sim_tensors()
         self._compute_observations(env_ids)
         return
@@ -342,17 +343,18 @@ class HumanoidAMPBase(VecTask):
         return obs
 
     def _reset_actors(self, env_ids):
+        self._root_states[env_ids] = self._initial_root_states[env_ids]
         self._dof_pos[env_ids] = self._initial_dof_pos[env_ids]
         self._dof_vel[env_ids] = self._initial_dof_vel[env_ids]
 
-        env_ids_int32 = env_ids.to(dtype=torch.int32)
-        self.gym.set_actor_root_state_tensor_indexed(self.sim,
-                                                     gymtorch.unwrap_tensor(self._initial_root_states),
-                                                     gymtorch.unwrap_tensor(env_ids_int32), len(env_ids_int32))
+        return
 
-        self.gym.set_dof_state_tensor_indexed(self.sim,
-                                              gymtorch.unwrap_tensor(self._dof_state),
-                                              gymtorch.unwrap_tensor(env_ids_int32), len(env_ids_int32))
+    def _reset_env_tensors(self, env_ids):
+        env_ids_int32 = env_ids.to(dtype=torch.int32)
+        self.gym.set_actor_root_state_tensor_indexed(self.sim, gymtorch.unwrap_tensor(self._root_states),
+                                                    gymtorch.unwrap_tensor(env_ids_int32), len(env_ids_int32))
+        self.gym.set_dof_state_tensor_indexed(self.sim, gymtorch.unwrap_tensor(self._dof_state),
+                                                    gymtorch.unwrap_tensor(env_ids_int32), len(env_ids_int32))
 
         self.progress_buf[env_ids] = 0
         self.reset_buf[env_ids] = 0

--- a/isaacgymenvs/tasks/humanoid_amp.py
+++ b/isaacgymenvs/tasks/humanoid_amp.py
@@ -159,22 +159,12 @@ class HumanoidAMP(HumanoidAMPBase):
         else:
             assert(False), "Unsupported state initialization strategy: {:s}".format(str(self._state_init))
 
-        self.progress_buf[env_ids] = 0
-        self.reset_buf[env_ids] = 0
-        self._terminate_buf[env_ids] = 0
-
         return
     
     def _reset_default(self, env_ids):
+        self._root_states[env_ids] = self._initial_root_states[env_ids]
         self._dof_pos[env_ids] = self._initial_dof_pos[env_ids]
         self._dof_vel[env_ids] = self._initial_dof_vel[env_ids]
-
-        env_ids_int32 = env_ids.to(dtype=torch.int32)
-        self.gym.set_actor_root_state_tensor_indexed(self.sim, gymtorch.unwrap_tensor(self._initial_root_states),
-                                                     gymtorch.unwrap_tensor(env_ids_int32), len(env_ids_int32))
-
-        self.gym.set_dof_state_tensor_indexed(self.sim, gymtorch.unwrap_tensor(self._dof_state),
-                                              gymtorch.unwrap_tensor(env_ids_int32), len(env_ids_int32))
 
         self._reset_default_env_ids = env_ids
         return
@@ -264,11 +254,6 @@ class HumanoidAMP(HumanoidAMPBase):
         self._dof_pos[env_ids] = dof_pos
         self._dof_vel[env_ids] = dof_vel
 
-        env_ids_int32 = env_ids.to(dtype=torch.int32)
-        self.gym.set_actor_root_state_tensor_indexed(self.sim, gymtorch.unwrap_tensor(self._root_states), 
-                                                    gymtorch.unwrap_tensor(env_ids_int32), len(env_ids_int32))
-        self.gym.set_dof_state_tensor_indexed(self.sim, gymtorch.unwrap_tensor(self._dof_state),
-                                                    gymtorch.unwrap_tensor(env_ids_int32), len(env_ids_int32))
         return
 
     def _update_hist_amp_obs(self, env_ids=None):


### PR DESCRIPTION
In HumanoidAMP, when using `Hybrid` as stateInit type ([this line](https://github.com/Charrrrrlie/IsaacGymEnvs/blob/70318e79a9bd210612056f1fd4f24222814a3d95/isaacgymenvs/cfg/task/HumanoidAMP.yaml#L17)), there is an error in the humanoid start pose.

⚠️It is caused by calling **self.gym.set_actor_root_state_tensor_indexed** and **self.gym.set_dof_state_tensor_indexed**   functions both in _reset_default and _reset_ref_state_init.
 (It is weird when we call the two functions once after default and ref state init. e.g. in the implementation of this PR, also in the source implementation in [ASE](https://github.com/nv-tlabs/ASE/tree/main))

The difference is shown below (the first picture shows the wrong initialization and the second is the correct one, using this PR). It seems the default state will somehow "overwrite" the reference state.

<img width="732" alt="error" src="https://github.com/NVIDIA-Omniverse/IsaacGymEnvs/assets/59760012/4940ef69-0465-4c43-98dd-b1bbb7e39867">

<img width="723" alt="correction" src="https://github.com/NVIDIA-Omniverse/IsaacGymEnvs/assets/59760012/34d53e2c-2063-4e7f-9c7c-cd728af37b66">

