### PR TITLE
Bug_Fix/Capture Videos in HumanoidAMP

### DIFF
--- a/isaacgymenvs/learning/common_agent.py
+++ b/isaacgymenvs/learning/common_agent.py
@@ -74,10 +74,11 @@ class CommonAgent(a2c_continuous.A2CAgent):
 
         self.init_rnn_from_model(self.model)
         self.last_lr = float(self.last_lr)
+        self.seq_len = config['seq_len']
 
         self.optimizer = optim.Adam(self.model.parameters(), float(self.last_lr), eps=1e-08, weight_decay=self.weight_decay)
 
-        if self.has_central_value:
+        if self.has_central_value: 
             cv_config = {
                 'state_shape' : torch_ext.shape_whc_to_cwh(self.state_shape), 
                 'value_size' : self.value_size,

--- a/isaacgymenvs/tasks/amp/humanoid_amp_base.py
+++ b/isaacgymenvs/tasks/amp/humanoid_amp_base.py
@@ -389,12 +389,11 @@ class HumanoidAMPBase(VecTask):
 
         return
 
-    def render(self):
+    def render(self, mode="rgb_array"):
         if self.viewer and self.camera_follow:
             self._update_camera()
-
-        super().render()
-        return
+            
+        return super().render(mode=mode)
 
     def _build_key_body_ids_tensor(self, env_ptr, actor_handle):
         body_ids = []


### PR DESCRIPTION
Hi when I want to record videos by running the command `train.py \
    task=HumanoidAMP \
    experiment=AMP_walk \
    capture_video=True \
    force_render=True \`
and it gives me the erro `TypeError: render() got an unexpected keyword argument ''mode`. It turns out the inherited render() in humanoid_amp_base.py does not receive the mode argument, also it needs to return the frame to really save the video.

Another small bug fix is in common_agent.py where self.seq_len has to be initialized before reading AMP dataset 